### PR TITLE
[FIX] return empty permissions string if cha:permissions() returns nil

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -512,29 +512,33 @@ function Yatline.coloreds.get:permissions()
 	if hovered then
 		local perm = hovered.cha:permissions()
 
-		local coloreds = {}
-		coloreds[1] = { " ", "black" }
+		if perm then
+			local coloreds = {}
+			coloreds[1] = { " ", "black" }
 
-		for i = 1, #perm do
-			local c = perm:sub(i, i)
+			for i = 1, #perm do
+				local c = perm:sub(i, i)
 
-			local fg = permissions_t_fg
-			if c == "-" then
-				fg = permissions_s_fg
-			elseif c == "r" then
-				fg = permissions_r_fg
-			elseif c == "w" then
-				fg = permissions_w_fg
-			elseif c == "x" or c == "s" or c == "S" or c == "t" or c == "T" then
-				fg = permissions_x_fg
+				local fg = permissions_t_fg
+				if c == "-" then
+					fg = permissions_s_fg
+				elseif c == "r" then
+					fg = permissions_r_fg
+				elseif c == "w" then
+					fg = permissions_w_fg
+				elseif c == "x" or c == "s" or c == "S" or c == "t" or c == "T" then
+					fg = permissions_x_fg
+				end
+
+				coloreds[i + 1] = { c, fg }
 			end
 
-			coloreds[i + 1] = { c, fg }
+			coloreds[#perm + 2] = { " ", "black" }
+
+			return coloreds
+		else
+			return ""
 		end
-
-		coloreds[#perm + 2] = { " ", "black" }
-
-		return coloreds
 	else
 		return ""
 	end


### PR DESCRIPTION
Kept getting following error when using yatline on windows:

  2024-10-03T12:16:10.693523Z ERROR yazi_plugin::utils::call: Failed to `render()` the `status` component:
runtime error: [string "yatline"]:518: attempt to get length of a nil value (local 'perm')
stack traceback:
	[C]: in metamethod 'len'
	[string "yatline"]:518: in local 'getter'
	[string "yatline"]:747: in upvalue 'config_side'
	[string "yatline"]:769: in upvalue 'config_line'
	[string "yatline"]:1006: in function <[string "yatline"]:1004>
	[C]: in field 'render_with'
	[string "root.lua"]:35: in function <[string "root.lua"]:32>
    at yazi-plugin\src\utils\call.rs:63

permissions are not defined in Cha.rs yazi-side when building for windows, so returning an empty string if no permissions were found seemed to be enough of a fix.

Making PR in case it helps someone, but since I'm not familiar with gh etiquette you can feel free to dismiss if I fucked up somehow