### PR TITLE
[FEAT] Add the option to display user and group ownership of the hovered file or directory

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -245,6 +245,18 @@ function Yatline.string.get:hovered_mime()
 	end
 end
 
+--- Gets the hovered file's user and group ownership of the current active tab.
+--- @return string ownership active tab's hovered file's path.
+function Yatline.string.get:hovered_ownership()
+	local hovered = cx.active.current.hovered
+
+	if hovered then
+		return ya.user_name(hovered.cha.uid) .. ":" .. ya.group_name(hovered.cha.gid)
+	else
+		return ""
+	end
+end
+
 --- Gets the hovered file's extension of the current active tab.
 --- @param show_icon boolean Whether or not an icon will be shown.
 --- @return string file_extension Current active tab's hovered file's extension.


### PR DESCRIPTION
This adds the option to show the ownership of the hovered entry by adding this to the desired section:
```lua
{type = "string", custom = false, name = "hovered_ownership"}
```
![image](https://github.com/user-attachments/assets/533a39f2-903e-4c5a-82ab-fb207b52c5af)
