### PR TITLE
feat: add utils function for hovered_name, hovered_path and tab_path components

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -330,7 +330,7 @@ end
 --- @class HoveredNameConfig
 --- @field trimed? boolean Whether to trim the filename if it's too long (default: false)
 --- @field max_length? integer Maximum length of the filename (default: 24)
---- @field trim_length? integer Length of each end when trimming (default: 6)
+--- @field trim_length? integer Length of each end when trimming (default: 10)
 --- @field show_symlink? boolean Whether to show symlink target (default: false)
 --- Gets the hovered file's name of the current active tab.
 --- @param config? HoveredNameConfig Configuration for getting hovered file's name
@@ -347,7 +347,7 @@ function Yatline.string.get:hovered_name(config)
 
 	local trimed = config.trimed or false
 	local max_length = config.max_length or 24
-	local trim_length = config.trim_length or 6
+	local trim_length = config.trim_length or 10
 	local show_symlink = config.show_symlink or false
 
 	local link_delimiter = " -> "

--- a/init.lua
+++ b/init.lua
@@ -368,7 +368,6 @@ function Yatline.string.get:hovered_name(config)
 	end
 end
 
-
 --- Configuration for getting hovered file's path
 --- @class HoveredPathConfig
 --- @field trimed? boolean Whether to trim the file path if it's too long (default: false)
@@ -459,9 +458,15 @@ function Yatline.string.get:hovered_file_extension(show_icon)
 	end
 end
 
+--- Configuration for getting curent active tab's path
+--- @class TabPathConfig
+--- @field trimed? boolean Whether to trim the current active tab's path if it's too long (default: false)
+--- @field max_length? integer Maximum length of the current active tab's path (default: 24)
+--- @field trim_length? integer Length of each end when trimming (default: 10)
 --- Gets the path of the current active tab.
+--- @param config? TabPathConfig Configuration for getting current active tab's path
 --- @return string path Current active tab's path.
-function Yatline.string.get:tab_path()
+function Yatline.string.get:tab_path(config)
 	local cwd = cx.active.current.cwd
 	local filter = cx.active.current.files.filter
 
@@ -476,7 +481,19 @@ function Yatline.string.get:tab_path()
 		suffix = string.format("%s, filter: %s)", search, tostring(filter))
 	end
 
-	return ya.readable_path(tostring(cx.active.current.cwd)) .. suffix
+	if not config then
+		return ya.readable_path(tostring(cwd)) .. suffix
+	end
+
+	local trimed = config.trimed or false
+	local max_length = config.max_length or 24
+	local trim_length = config.trim_length or 10
+
+	if trimed then
+		return trim_filename(ya.readable_path(tostring(cwd)), max_length, trim_length) .. suffix
+	else
+		return ya.readable_path(tostring(cwd)) .. suffix
+	end
 end
 
 --- Gets the mode of active tab.

--- a/init.lua
+++ b/init.lua
@@ -242,11 +242,18 @@ function Yatline.string.get:hovered_name(config)
 	local trim_length = config.trim_length or 6
 	local show_symlink = config.show_symlink or false
 
-	local linked = (show_symlink and hovered.link_to ~= nil) and (" -> " .. tostring(hovered.link_to)) or ""
+	local link_delimiter = " -> "
+	local linked = (show_symlink and hovered.link_to ~= nil) and (link_delimiter .. tostring(hovered.link_to)) or ""
 
 	if trimed then
 		local trimmed_name = trim_filename(hovered.name, max_length, trim_length)
-		local trimmed_linked = trim_filename(linked, max_length, trim_length)
+		local trimmed_linked = #linked ~= 0
+				and link_delimiter .. trim_filename(
+					string.sub(linked, #link_delimiter + 1, -1),
+					max_length,
+					trim_length
+				)
+			or ""
 		return trimmed_name .. trimmed_linked
 	else
 		return hovered.name .. linked

--- a/init.lua
+++ b/init.lua
@@ -368,14 +368,33 @@ function Yatline.string.get:hovered_name(config)
 	end
 end
 
+
+--- Configuration for getting hovered file's path
+--- @class HoveredPathConfig
+--- @field trimed? boolean Whether to trim the file path if it's too long (default: false)
+--- @field max_length? integer Maximum length of the file path (default: 24)
+--- @field trim_length? integer Length of each end when trimming (default: 10)
 --- Gets the hovered file's path of the current active tab.
+--- @param config? HoveredPathConfig Configuration for getting hovered file's path
 --- @return string path Current active tab's hovered file's path.
-function Yatline.string.get:hovered_path()
+function Yatline.string.get:hovered_path(config)
 	local hovered = cx.active.current.hovered
-	if hovered then
-		return ya.readable_path(tostring(hovered.url))
-	else
+	if not hovered then
 		return ""
+	end
+
+	if not config then
+		return ya.readable_path(tostring(hovered.url))
+	end
+
+	local trimed = config.trimed or false
+	local max_length = config.max_length or 24
+	local trim_length = config.trim_length or 10
+
+	if trimed then
+		return trim_filename(ya.readable_path(tostring(hovered.url)), max_length, trim_length)
+	else
+		return ya.readable_path(tostring(hovered.url))
 	end
 end
 


### PR DESCRIPTION
add params config for hovered_name component

trimed: boolean Whether to trim the filename if it's too long (default: false)

- max_length: integer Maximum length of the filename (default: 24)
- trim_length: integer Length of each end when trimming (default: 6)

show_symlink: boolean Whether to show symlink target (default: false)

```lua
{
type = "string",
custom = false,
name = "hovered_name",
params = { { trimed = true, show_symlink = true } },
},
```

![image](https://github.com/user-attachments/assets/56433c38-89bc-4549-ac07-848d274daec6)

Set trim 7 chars from both ends when filename > 24
```lua
{
type = "string",
custom = false,
name = "hovered_name",
params = { { trimed = true, show_symlink = true, max_length=24, trim_length=7 } },
},
```

![image](https://github.com/user-attachments/assets/a129eed2-58d3-4f6b-859e-ed425fd182ac)
