### PR TITLE
Add 'filter' section

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -59,6 +59,12 @@ local permissions_s_fg
 
 local tab_width
 
+local filter_fg
+local search_label
+local filter_label
+local no_filter_label
+local flatten_label
+	
 local selected_icon
 local copied_icon
 local cut_icon
@@ -748,6 +754,46 @@ function Yatline.coloreds.get:permissions()
 	end
 end
 
+--- Configuration for getting curent filter
+--- @class TabPathConfig
+--- @field search_label? string Search label (default: "search")
+--- @field filter_label? string Filter label (default: "filter")
+--- @field no_filter_label? string No filter label (default: "no filter")
+--- @field flatten_label? string Flatten label (default: "flatten")
+--- @field fg_color? string Foreground color of the filter (default: "brightyellow")
+--- Gets the specified file filters, i.e. search / filter / flatten (empty search).
+--- @param config? TabPathConfig Configuration for getting current filter
+--- @return Coloreds coloreds Current active tab's file filter
+function Yatline.coloreds.get:filter()
+	local cwd = cx.active.current.cwd
+	local filter = cx.active.current.files.filter
+
+	local text
+
+	local search = ""
+	if cwd.is_search then
+		search = #cwd:frag() > 0 and string.format("%s: %s", search_label, cwd:frag()) or flatten_label
+	end
+
+	if not filter then
+		text = search == "" and search or search
+	elseif search == "" then
+		text = string.format("%s: %s", filter_label, tostring(filter))
+	else
+		text = string.format("%s, %s: %s", search, filter_label, tostring(filter))
+	end
+
+	if text == "" then
+		return { { string.format("%s", no_filter_label), filter_fg }, }
+	end
+
+	local coloreds = {
+		{ string.format(" %s ", text), filter_fg },
+	}
+
+	return coloreds
+end
+
 --- Gets the number of selected and yanked files of the active tab.
 --- @return Coloreds coloreds Active tab's number of selected and yanked files.
 function Yatline.coloreds.get:count()
@@ -1131,6 +1177,25 @@ return {
 		permissions_w_fg = config.permissions_w_fg or "red"
 		permissions_x_fg = config.permissions_x_fg or "cyan"
 		permissions_s_fg = config.permissions_s_fg or "white"
+
+		local default_filter_fg = "brightyellow"
+		local default_search_label = " search"
+		local default_filter_label = " filter"
+		local default_no_filter_label = ""
+		local default_flatten_label = " flatten"
+		if config.filter then
+			filter_fg = config.filter.fg
+			search_label = config.filter.search_label and config.filter.search_label or default_search_label
+			filter_label = config.filter.filter_label and config.filter.filter_label or default_filter_label
+			no_filter_label = config.filter.no_filter_label and config.filter.no_filter_label or default_no_filter_label
+			flatten_label = config.filter.flatten_label and config.filter.flatten_label or default_flatten_label
+		else
+			filter_fg = default_filter_fg
+			search_label = default_search_label
+			filter_label = default_filter_label
+			no_filter_label = default_no_filter_label
+			flatten_label = default_flatten_label
+		end
 
 		if config.selected then
 			selected_fg = config.selected.fg

--- a/init.lua
+++ b/init.lua
@@ -756,12 +756,12 @@ end
 
 --- Configuration for getting curent filter
 --- @class TabPathConfig
---- @field search_label? string Search label (default: "search")
---- @field filter_label? string Filter label (default: "filter")
---- @field no_filter_label? string No filter label (default: "no filter")
---- @field flatten_label? string Flatten label (default: "flatten")
---- @field fg_color? string Foreground color of the filter (default: "brightyellow")
---- Gets the specified file filters, i.e. search / filter / flatten (empty search).
+--- @field search_label? string Search label
+--- @field filter_label? string Filter label
+--- @field no_filter_label? string No filter label
+--- @field flatten_label? string Flatten label
+--- @field fg_color? string Foreground color of the filter
+--- Gets the specified file filters, i.e. search / filter / flatten (empty search)
 --- @param config? TabPathConfig Configuration for getting current filter
 --- @return Coloreds coloreds Current active tab's file filter
 function Yatline.coloreds.get:filter()

--- a/init.lua
+++ b/init.lua
@@ -783,7 +783,11 @@ function Yatline.coloreds.get:filter()
 		text = string.format("%s, %s: %s", search, filter_label, tostring(filter))
 	end
 
-	return { { string.format(" %s ", text ~= "" and text or no_filter_label), filter_fg }, }
+	if text == "" then
+		text = no_filter_label
+	end
+
+	return { { text ~= "" and string.format(" %s ", text) or "", filter_fg }, }
 end
 
 --- Gets the number of selected and yanked files of the active tab.

--- a/init.lua
+++ b/init.lua
@@ -1180,11 +1180,11 @@ return {
 		local default_no_filter_label = ""
 		local default_flatten_label = " flatten"
 		if config.filter then
-			filter_fg = config.filter.fg
-			search_label = config.filter.search_label and config.filter.search_label or default_search_label
-			filter_label = config.filter.filter_label and config.filter.filter_label or default_filter_label
-			no_filter_label = config.filter.no_filter_label and config.filter.no_filter_label or default_no_filter_label
-			flatten_label = config.filter.flatten_label and config.filter.flatten_label or default_flatten_label
+			filter_fg = config.filter.fg or default_filter_fg
+			search_label = config.filter.search_label or default_search_label
+			filter_label = config.filter.filter_label or default_filter_label
+			no_filter_label = config.filter.no_filter_label or default_no_filter_label
+			flatten_label = config.filter.flatten_label or default_flatten_label
 		else
 			filter_fg = default_filter_fg
 			search_label = default_search_label

--- a/init.lua
+++ b/init.lua
@@ -783,15 +783,7 @@ function Yatline.coloreds.get:filter()
 		text = string.format("%s, %s: %s", search, filter_label, tostring(filter))
 	end
 
-	if text == "" then
-		return { { string.format("%s", no_filter_label), filter_fg }, }
-	end
-
-	local coloreds = {
-		{ string.format(" %s ", text), filter_fg },
-	}
-
-	return coloreds
+	return { { string.format(" %s ", text ~= "" and text or no_filter_label), filter_fg }, }
 end
 
 --- Gets the number of selected and yanked files of the active tab.


### PR DESCRIPTION
Hello, please kindly consider my addition:

The filter part of the `tab_path` section to be more pronounced as it's easy to forget your file filter is on.
As the `tab_path` is of type string and not coloreds, changing it to coloreds would be a breaking change.

Therefore I added separate `filter` coloreds section.

However, if both `tab_path` and `filter` sections are visible, the filter is duplicated. 
@imsi32  I would appreciate your comments how to solve this without adding disable_filter param to `tab_path` or cause breaking change by converting `tab_path` from string to coloreds.

What it does wit default settings:
Showing 'flatten' for empty search:
![image](https://github.com/user-attachments/assets/4e798bb5-8173-40ef-8a75-e20966eeac76)

Showing search and/or filter:
![image](https://github.com/user-attachments/assets/89d06578-1ece-4121-8c16-200ecc6e95f0)

