### PR TITLE
feat: fallback to uid/gid on ownership

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -433,10 +433,11 @@ function Yatline.string.get:hovered_ownership()
 		if not hovered.cha.uid or not hovered.cha.gid then
 			return ""
 		end
-		if not ya.user_name(hovered.cha.uid) or not ya.group_name(hovered.cha.gid) then
-			return ""
-		end
-		return ya.user_name(hovered.cha.uid) .. ":" .. ya.group_name(hovered.cha.gid)
+
+		local username = ya.user_name(hovered.cha.uid) or tostring(hovered.cha.uid)
+		local groupname = ya.group_name(hovered.cha.gid) or tostring(hovered.cha.gid)
+
+		return username .. ":" .. groupname
 	else
 		return ""
 	end


### PR DESCRIPTION
Maintain a consistent UI layout and provide the raw uid/gid when they are available. We only need to hide the element when we can't even fetch those values.

Follow up from https://github.com/imsi32/yatline.yazi/issues/53#issuecomment-2924480984 