### PR TITLE
[FIX] guard table unpack against invalid progress

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -1371,11 +1371,19 @@ return {
 					local right_line = config_line(status_line.right, Side.RIGHT)
 					local right_width = right_line:width()
 
-					return {
+					local progress_components = Progress:new(self._area, right_width):redraw()
+					local result = {
 						config_paragraph(self._area, left_line),
 						ui.Text(right_line):area(self._area):align(ui.Text.RIGHT),
-						table.unpack(Progress:new(self._area, right_width):redraw()),
 					}
+
+					if progress_components and type(progress_components) == "table" then
+						for _, component in ipairs(progress_components) do
+							table.insert(result, component)
+						end
+					end
+
+					return result
 				end
 
 				Status.children_add = function()


### PR DESCRIPTION
2025-06-06T16:42:27.752240Z ERROR yazi::root: Failed to redraw the `Root` component:
runtime error: attempt to get length of a Gauge value stack traceback:
[C]: in ?
[C]: in function 'table.unpack'
[string "yatline"]:1377: in function <[string "yatline"]:1369>
[C]: in field 'redraw'
[string "root.lua"]:46: in function <[string "root.lua"]:43>
stack traceback:
[C]: in field 'redraw'
[string "root.lua"]:46: in function <[string "root.lua"]:43>
    at yazi-fm/src/root.rs:33

Should close https://github.com/imsi32/yatline.yazi/issues/56