### PR TITLE
Fix: Use 'ui.truncate' instead of 'ya.truncate'

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -602,7 +602,7 @@ function Yatline.line.get:tabs(side)
 	for i = 1, tabs do
 		local text = i
 		if tab_width > 2 then
-			text = ya.truncate(text .. " " .. cx.tabs[i].name, { max = tab_width })
+			text = ui.truncate(text .. " " .. cx.tabs[i].name, { max = tab_width })
 		end
 
 		separator_style = { bg = nil, fg = nil }


### PR DESCRIPTION
Fixes #66.

`ya.truncate` is deprecated. See https://github.com/sxyazi/yazi/pull/2939.