### PR TITLE
Add Gitplugin which shows Git information on yatline

### DIFF
--- a/README-git-status.md
+++ b/README-git-status.md
@@ -1,0 +1,130 @@
+# Git Repository Status Component
+
+A feature-rich Git repository status component for [yatline.yazi](https://github.com/imsi32/yatline.yazi).
+
+## Features
+
+✨ **Comprehensive Git Information**
+
+- Current branch name or commit hash (detached HEAD)
+- Commits ahead/behind upstream
+- Clean/dirty repository indicator
+- Detailed file change statistics
+
+📊 **File Change Tracking**
+
+- Staged files
+- Added files
+- Modified files
+- Deleted files
+- Renamed files
+- Untracked files
+
+🎨 **Highly Customizable**
+
+- Custom icons (UTF-8 or Nerd Fonts)
+- Configurable colors
+- Multiple display modes (detailed or compact)
+- Optional features (stash count, clean indicator)
+
+## Quick Start
+
+1. **Copy the component file:**
+
+   ```bash
+   cp git-repo-status.lua ~/.config/yazi/plugins/yatline.yazi/
+   ```
+
+2. **Add to your Yazi config** (`~/.config/yazi/init.lua`):
+
+   ```lua
+   require("yatline"):setup({
+       -- Your yatline configuration
+       status_line = {
+           left = {
+               section_c = {
+                   { type = "coloreds", custom = false, name = "git_repo_status" },
+               },
+           },
+       },
+   })
+
+   -- Initialize git status component (auto-registers with Yatline)
+   require("yatline.git-repo-status"):setup()
+   ```
+
+3. **Restart Yazi** and navigate to a Git repository!
+
+## Documentation
+
+Full documentation is available in [docs/Git-Repo-Status.md](docs/Git-Repo-Status.md).
+
+## Examples
+
+See [examples/git-status-integration.lua](examples/git-status-integration.lua) for a complete integration example.
+
+## Display Samples
+
+**Clean repository:**
+
+```shell
+ main ✓
+```
+
+**Dirty repository with changes:**
+
+```shell
+  main ⇡3 ✗ ●2 +1 ~2 -1 ?3 
+```
+
+- `main` - Current branch `main`
+- `⇡3` - 3 commits ahead of upstream
+- `✗`  - Dirty repository
+- `●2` - 2 staged files
+- `+1` - 1 added file
+- `~2` - 2 modified files
+- `-1` - 1 deleted file
+- `?3` - 3 untracked files
+
+**Compact mode:**
+
+```shell
+  main ⇡2 (5) 
+```
+
+## Requirements
+
+- [Yazi](https://github.com/sxyazi/yazi) file manager
+- [yatline.yazi](https://github.com/imsi32/yatline.yazi) plugin
+- Git command-line tool
+
+## Configuration
+
+Customize icons and colors to match your theme:
+
+```lua
+require("yatline.git-repo-status"):setup({
+    icons = {
+        branch = "󰘬",
+        clean = "",
+        dirty = "",
+        -- ... more icons
+    },
+    colors = {
+        branch = "blue",
+        clean = "green",
+        dirty = "yellow",
+        -- ... more colors
+    },
+    compact = false,
+    show_clean = true,
+})
+```
+
+## License
+
+This component follows the same license as yatline.yazi.
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit issues or pull requests.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # yatline.yazi
+
 The first Yazi plugin for customizing both header-line and status-line.
 
 ![yatline](https://github.com/user-attachments/assets/61013ec8-7fd9-42df-a9f4-f254663871fe)
@@ -7,13 +8,18 @@ The first Yazi plugin for customizing both header-line and status-line.
 > Check out [wiki](https://github.com/imsi32/yatline.yazi/wiki) for installation steps, configuration and further information.
 
 ## Features
+
 - Lualine-like Design
 - Flexible
 - Simple
 - Automatic Configuration
 - Themes (See: [yatline-themes](https://github.com/imsi32/yatline-themes))
 - Add-ons (See: [yatline-addons](https://github.com/imsi32/yatline-addons))
+- Native Git Repository Status Component (See: [Git Repository Status Component Readme](README-git-status.md))
+
+Sample configuration at [examples/git-status-integration.lua](examples/git-status-integration.lua).
 
 ## Credits
+
 - [Lualine](https://github.com/nvim-lualine/lualine.nvim)
 - [Yazi](https://github.com/sxyazi/yazi)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,190 @@
+# Git Status Component - Architecture Diagram
+
+```txt
+┌─────────────────────────────────────────────────────────────────────┐
+│                         Yazi File Manager                           │
+│                                                                     │
+│  ┌─────────────────────────────────────────────────────────────┐    │
+│  │                    yatline Plugin                           │    │
+│  │                                                             │    │
+│  │  ┌──────────────────────────────────────────────────────┐   │    │
+│  │  │           Status Line Components                     │   │    │
+│  │  │                                                      │   │    │
+│  │  │  Section A    Section B       Section C              │   │    │
+│  │  │  ┌────────┐  ┌────────┐      ┌──────────────────┐    │   │    │
+│  │  │  │ Mode   │  │ Size   │      │ Git Status ★     │    │   │   │
+│  │  │  └────────┘  └────────┘      └──────────────────┘     │   │   │
+│  │  │                                       │               │   │   │
+│  │  └───────────────────────────────────────┼───────────────┘   │   │
+│  │                                          │                   │   │
+│  │  ┌───────────────────────────────────────▼───────────────┐  │   │
+│  │  │       yatline.coloreds.get.git_repo_status()          │  │   │
+│  │  └───────────────────────────────────────┬───────────────┘  │   │
+│  └──────────────────────────────────────────┼──────────────────┘   │
+│                                             │                       │
+└─────────────────────────────────────────────┼───────────────────────┘
+                                              │
+                    ┌─────────────────────────▼─────────────────────┐
+                    │     git-repo-status.lua Component             │
+                    │                                               │
+                    │  ┌──────────────────────────────────────┐   │
+                    │  │  M.get_status()                      │   │
+                    │  │  - Gets current directory from cx    │   │
+                    │  │  - Calls get_git_info()             │   │
+                    │  │  - Formats as coloreds array        │   │
+                    │  └────────────────┬─────────────────────┘   │
+                    │                   │                          │
+                    │  ┌────────────────▼──────────────────────┐  │
+                    │  │  get_git_info(path)                   │  │
+                    │  │  - Executes Git commands              │  │
+                    │  │  - Parses output                      │  │
+                    │  │  - Returns info table                 │  │
+                    │  └────────────────┬──────────────────────┘  │
+                    │                   │                          │
+                    │  ┌────────────────▼──────────────────────┐  │
+                    │  │  format_git_info(info, config)        │  │
+                    │  │  - Applies icons                      │  │
+                    │  │  - Applies colors                     │  │
+                    │  │  - Returns [{text, color}, ...]      │  │
+                    │  └───────────────────────────────────────┘  │
+                    │                                               │
+                    └───────────────────┬───────────────────────────┘
+                                        │
+                        ┌───────────────▼────────────────┐
+                        │     Git Repository             │
+                        │                                │
+                        │  Commands executed:            │
+                        │  - git rev-parse               │
+                        │  - git symbolic-ref            │
+                        │  - git rev-list                │
+                        │  - git status --porcelain      │
+                        │  - git stash list              │
+                        └────────────────────────────────┘
+
+
+Data Flow
+═════════
+
+1. User Configuration
+   └─> M.setup(config) - Merges user config with defaults
+
+2. Component Registration
+   └─> yatline.coloreds.get.git_repo_status = M.get_status
+
+3. Runtime Execution (every render)
+   └─> yatline calls git_repo_status()
+       └─> M.get_status()
+           └─> get_git_info(path)
+               ├─> Git command: check if in repo
+               ├─> Git command: get branch
+               ├─> Git command: get ahead/behind
+               ├─> Git command: get file status
+               └─> Git command: get stash count
+           └─> format_git_info(info, config)
+               └─> Returns: {{"  main ", "blue"}, {"⇡3 ", "green"}, ...}
+       └─> yatline renders coloreds with proper styling
+
+
+Output Example
+══════════════
+
+Config:
+  show_branch = true
+  show_ahead_behind = true
+  compact = false
+
+Git State:
+  Branch: main
+  Ahead: 3 commits
+  Behind: 0 commits
+  Staged: 2 files
+  Modified: 1 file
+  Untracked: 3 files
+
+Coloreds Output:
+  [
+    {"  main ", "blue"},
+    {"⇡3 ", "green"},
+    {"✗ ", "yellow"},
+    {"●2 ", "cyan"},
+    {"~1 ", "yellow"},
+    {"?3 ", "magenta"}
+  ]
+
+Rendered Display:
+  [blue] main [green]⇡3 [yellow]✗ [cyan]●2 [yellow]~1 [magenta]?3
+
+
+Configuration Flow
+══════════════════
+
+Default Config
+     │
+     ├─> Icons (branch, clean, dirty, etc.)
+     ├─> Colors (blue, green, yellow, etc.)
+     └─> Display Options (show_branch, compact, etc.)
+     │
+     ▼
+User Config (passed to setup())
+     │
+     └─> Merged with defaults
+         │
+         ▼
+    Runtime Config
+         │
+         ├─> Used by format_git_info()
+         └─> Determines what to display and how
+```
+
+## Component Lifecycle
+
+```txt
+┌──────────────────────────────────────────────────────────────┐
+│                    Initialization Phase                       │
+└───────────────────────────────┬──────────────────────────────┘
+                                │
+        ┌───────────────────────┼───────────────────────┐
+        │                       │                       │
+        ▼                       ▼                       ▼
+  require()              M.setup(config)      Register with yatline
+  Load module         Merge configuration    Set as coloreds getter
+        │                       │                       │
+        └───────────────────────┴───────────────────────┘
+                                │
+┌───────────────────────────────▼──────────────────────────────┐
+│                      Runtime Phase                            │
+└───────────────────────────────┬──────────────────────────────┘
+                                │
+                                │  (triggered on every render)
+                                │
+                ┌───────────────▼───────────────┐
+                │  yatline renders status line  │
+                └───────────────┬───────────────┘
+                                │
+                ┌───────────────▼───────────────┐
+                │  calls git_repo_status()      │
+                └───────────────┬───────────────┘
+                                │
+                ┌───────────────▼───────────────┐
+                │  M.get_status() executed      │
+                └───────────────┬───────────────┘
+                                │
+                        ┌───────┴───────┐
+                        │               │
+                        ▼               ▼
+                 get_git_info()   format_git_info()
+                        │               │
+                        └───────┬───────┘
+                                │
+                ┌───────────────▼───────────────┐
+                │  Return coloreds array        │
+                └───────────────┬───────────────┘
+                                │
+                ┌───────────────▼───────────────┐
+                │  yatline applies styling      │
+                └───────────────┬───────────────┘
+                                │
+                ┌───────────────▼───────────────┐
+                │  Rendered in status line      │
+                └───────────────────────────────┘
+```

--- a/examples/git-status-integration.lua
+++ b/examples/git-status-integration.lua
@@ -1,0 +1,116 @@
+-- Example integration of git-repo-status component with yatline
+-- Save this in your ~/.config/yazi/init.lua
+
+-- Initialize yatline with your configuration
+require("yatline"):setup({
+	-- Configure separators
+	section_separator = { open = "", close = "" },
+	part_separator = { open = "", close = "" },
+	inverse_separator = { open = "", close = "" },
+
+	-- Configure style
+	style_a = {
+		fg = "black",
+		bg_mode = {
+			normal = "#a89984",
+			select = "#d79921",
+			un_set = "#d65d0e"
+		}
+	},
+	style_b = { bg = "#665c54", fg = "#ebdbb2" },
+	style_c = { bg = "#3c3836", fg = "#a89984" },
+
+	-- Configure header line
+	header_line = {
+		left = {
+			section_a = {
+				{ type = "line", custom = false, name = "tabs", params = { "left" } },
+			},
+			section_b = {},
+			section_c = {},
+		},
+		right = {
+			section_a = {
+				{ type = "string", custom = false, name = "date", params = { "%A, %d %B %Y" } },
+			},
+			section_b = {
+				{ type = "string", custom = false, name = "date", params = { "%X" } },
+			},
+			section_c = {},
+		},
+	},
+
+	-- Configure status line with git status component
+	status_line = {
+		left = {
+			section_a = {
+				{ type = "string", custom = false, name = "tab_mode" },
+			},
+			section_b = {
+				{ type = "string", custom = false, name = "hovered_size" },
+			},
+			section_c = {
+				{ type = "string", custom = false, name = "hovered_name" },
+				-- Add git status component here
+				{ type = "coloreds", custom = false, name = "git_repo_status" },
+			},
+		},
+		right = {
+			section_a = {
+				{ type = "string", custom = false, name = "cursor_position" },
+			},
+			section_b = {
+				{ type = "string", custom = false, name = "cursor_percentage" },
+			},
+			section_c = {
+				{ type = "string", custom = false, name = "hovered_file_extension", params = { true } },
+				{ type = "coloreds", custom = false, name = "permissions" },
+			},
+		},
+	},
+})
+
+-- Initialize git status component (auto-registers with Yatline)
+require("yatline.git-repo-status"):setup()
+
+-- OR: Custom setup with your preferences
+--[[
+require("yatline.git-repo-status"):setup({
+	-- Customize icons (using Nerd Font icons)
+	icons = {
+		branch = "󰘬",      -- Nerd Font git branch icon
+		ahead = "⇡",
+		behind = "⇣",
+		clean = "",
+		dirty = "",
+		added = "",
+		deleted = "",
+		modified = "",
+		renamed = "󰁕",
+		untracked = "",
+		staged = "",
+	},
+
+	-- Customize colors (match your theme)
+	colors = {
+		branch = "#89b4fa",      -- Catppuccin blue
+		ahead = "#a6e3a1",       -- Catppuccin green
+		behind = "#f38ba8",      -- Catppuccin red
+		clean = "#a6e3a1",       -- Catppuccin green
+		dirty = "#f9e2af",       -- Catppuccin yellow
+		added = "#a6e3a1",
+		deleted = "#f38ba8",
+		modified = "#f9e2af",
+		renamed = "#89b4fa",
+		untracked = "#cba6f7",   -- Catppuccin mauve
+		staged = "#94e2d5",      -- Catppuccin teal
+	},
+
+	-- Display options
+	show_branch = true,
+	show_ahead_behind = true,
+	show_stashes = false,
+	show_clean = true,
+	compact = false,  -- Set to true for minimal display
+})
+--]]

--- a/git-repo-status.lua
+++ b/git-repo-status.lua
@@ -295,9 +295,10 @@ function M.get_status(custom_config)
 
 	local path = tostring(cwd)
 
-	-- Check cache
-	local now = os.time() * 1000 -- Convert to milliseconds
-	if cache.path == path and cache.data and (now - cache.timestamp) < config.cache_ttl then
+	-- Check cache (os.time() returns seconds, so convert TTL from ms to seconds)
+	local now = os.time()
+	local cache_ttl_seconds = config.cache_ttl / 1000
+	if cache.path == path and cache.data and (now - cache.timestamp) < cache_ttl_seconds then
 		return cache.data
 	end
 

--- a/git-repo-status.lua
+++ b/git-repo-status.lua
@@ -1,0 +1,344 @@
+--- @diagnostic disable: undefined-global
+--- Git Repository Status Component for Yatline
+--- Shows repository state, commits ahead/behind, and file changes
+
+local M = {}
+
+-- Cache for git status to avoid blocking UI
+local cache = {
+	path = nil,
+	data = nil,
+	timestamp = 0,
+	ttl = 5000, -- Cache TTL in milliseconds (5 seconds)
+}
+
+--- Default configuration
+M.config = {
+	-- Icons for different git states
+	icons = {
+		branch = "",      -- Branch icon
+		ahead = "⇡",       -- Commits ahead
+		behind = "⇣",      -- Commits behind
+		clean = "✓",       -- Clean repository
+		dirty = "✗",       -- Dirty repository
+		added = "+",       -- Added files
+		deleted = "-",     -- Deleted files
+		modified = "~",    -- Modified files
+		renamed = "»",     -- Renamed files
+		untracked = "?",   -- Untracked files
+		staged = "●",      -- Staged files
+	},
+
+	-- Colors for different states
+	colors = {
+		branch = "blue",
+		ahead = "green",
+		behind = "red",
+		clean = "green",
+		dirty = "yellow",
+		added = "green",
+		deleted = "red",
+		modified = "yellow",
+		renamed = "blue",
+		untracked = "magenta",
+		staged = "cyan",
+	},
+
+	-- Display options
+	show_branch = true,
+	show_ahead_behind = true,
+	show_stashes = true,
+	show_clean = true,  -- Show indicator when repo is clean
+	compact = false,    -- Compact mode shows fewer details
+
+	-- Performance options
+	cache_ttl = 5000,   -- Cache duration in milliseconds
+
+	-- Part separators (can be set manually or will be auto-detected)
+	part_separator_open = "",
+	part_separator_close = "",
+}--- Get git repository information for the current directory
+--- @param path string The current directory path
+--- @return table|nil git_info Table containing git repository status or nil if not in a git repo
+local function get_git_info(path)
+	-- Use simple shell command approach
+	local function run_git_cmd(args)
+		local cmd = "cd " .. ya.quote(path) .. " && git " .. args .. " 2>/dev/null"
+		local handle = io.popen(cmd)
+		if not handle then return nil end
+		local result = handle:read("*a")
+		local success = handle:close()
+		if not success then return nil end
+		return result
+	end
+
+	-- Check if we're in a git repository
+	local git_check = run_git_cmd("rev-parse --git-dir")
+	if not git_check or git_check == "" then
+		return nil
+	end
+
+	local info = {}
+
+	-- Get current branch name
+	local branch = run_git_cmd("symbolic-ref --short HEAD")
+	if branch and branch ~= "" then
+		info.branch = branch:gsub("%s+", "")
+	else
+		-- Detached HEAD - get short commit hash
+		local hash = run_git_cmd("rev-parse --short HEAD")
+		if hash and hash ~= "" then
+			info.branch = hash:gsub("%s+", "")
+			info.detached = true
+		end
+	end
+
+	-- Get ahead/behind counts
+	local ahead_behind = run_git_cmd("rev-list --left-right --count HEAD...@{upstream}")
+	if ahead_behind and ahead_behind ~= "" then
+		local ahead, behind = ahead_behind:match("(%d+)%s+(%d+)")
+		info.ahead = tonumber(ahead) or 0
+		info.behind = tonumber(behind) or 0
+	else
+		info.ahead = 0
+		info.behind = 0
+	end
+
+	-- Get file status counts
+	local status = run_git_cmd("status --porcelain --untracked-files=all")
+
+	info.staged = 0
+	info.modified = 0
+	info.deleted = 0
+	info.renamed = 0
+	info.untracked = 0
+	info.added = 0
+
+	if status and status ~= "" then
+		for line in status:gmatch("[^\r\n]+") do
+			local index_status = line:sub(1, 1)
+			local work_status = line:sub(2, 2)
+
+			-- Staged changes
+			if index_status == "A" then
+				info.staged = info.staged + 1
+				info.added = info.added + 1
+			elseif index_status == "M" then
+				info.staged = info.staged + 1
+				info.modified = info.modified + 1
+			elseif index_status == "D" then
+				info.staged = info.staged + 1
+				info.deleted = info.deleted + 1
+			elseif index_status == "R" then
+				info.staged = info.staged + 1
+				info.renamed = info.renamed + 1
+			end
+
+			-- Working tree changes
+			if work_status == "M" then
+				info.modified = info.modified + 1
+			elseif work_status == "D" then
+				info.deleted = info.deleted + 1
+			end
+
+			-- Untracked files
+			if index_status == "?" and work_status == "?" then
+				info.untracked = info.untracked + 1
+			end
+		end
+	end
+
+	-- Check if repository is clean
+	info.clean = (info.staged + info.modified + info.deleted + info.untracked + info.added + info.renamed) == 0
+
+	-- Get stash count (optional)
+	if M.config.show_stashes then
+		local stash_list = run_git_cmd("stash list")
+		if stash_list and stash_list ~= "" then
+			local count = 0
+			for _ in stash_list:gmatch("[^\r\n]+") do
+				count = count + 1
+			end
+			info.stashes = count
+		else
+			info.stashes = 0
+		end
+	else
+		info.stashes = 0
+	end
+
+	return info
+end
+
+--- Format git information as a coloreds array
+--- @param info table Git repository information
+--- @param config table Configuration options
+--- @return table coloreds Array of {text, color} pairs
+local function format_git_info(info, config)
+	local coloreds = {}
+	local icons = config.icons
+	local colors = config.colors
+
+	-- Get part separators from Yatline config
+	local part_sep_open = ""
+	local part_sep_close = ""
+	if Yatline and Yatline.config and Yatline.config.part_separator then
+		part_sep_open = Yatline.config.part_separator.open or ""
+		part_sep_close = Yatline.config.part_separator.close or ""
+	end
+
+	-- Add opening separator if we have content
+	if part_sep_open ~= "" then
+		table.insert(coloreds, { part_sep_open .. " ", "reset" })
+	end
+
+	-- Branch name
+	if config.show_branch and info.branch then
+		local branch_text = icons.branch .. "" .. info.branch
+		if info.detached then
+			branch_text = branch_text .. " (detached)"
+		end
+		table.insert(coloreds, { branch_text .. " ", colors.branch })
+	end
+
+	-- Ahead/Behind
+	if config.show_ahead_behind then
+		if info.ahead > 0 then
+			table.insert(coloreds, { icons.ahead .. info.ahead .. " ", colors.ahead })
+		end
+		if info.behind > 0 then
+			table.insert(coloreds, { icons.behind .. info.behind .. " ", colors.behind })
+		end
+	end
+
+	-- Repository state
+	if info.clean then
+		if config.show_clean then
+			table.insert(coloreds, { icons.clean .. " ", colors.clean })
+		end
+	else
+		table.insert(coloreds, { icons.dirty .. " ", colors.dirty })
+	end
+
+	-- File changes (detailed or compact)
+	if not info.clean then
+		if config.compact then
+			-- Compact mode: just show if there are changes
+			local total = info.staged + info.modified + info.deleted + info.untracked
+			if total > 0 then
+				table.insert(coloreds, { "(" .. total .. ") ", colors.dirty })
+			end
+		else
+			-- Detailed mode: show each type of change
+			if info.staged > 0 then
+				table.insert(coloreds, { icons.staged .. info.staged .. " ", colors.staged })
+			end
+			if info.added > 0 then
+				table.insert(coloreds, { icons.added .. info.added .. " ", colors.added })
+			end
+			if info.modified > 0 then
+				table.insert(coloreds, { icons.modified .. info.modified .. " ", colors.modified })
+			end
+			if info.deleted > 0 then
+				table.insert(coloreds, { icons.deleted .. info.deleted .. " ", colors.deleted })
+			end
+			if info.renamed > 0 then
+				table.insert(coloreds, { icons.renamed .. info.renamed .. " ", colors.renamed })
+			end
+			if info.untracked > 0 then
+				table.insert(coloreds, { icons.untracked .. info.untracked .. " ", colors.untracked })
+			end
+		end
+	end
+
+	-- Stashes (optional)
+	if config.show_stashes and info.stashes > 0 then
+		table.insert(coloreds, { "📦" .. info.stashes .. " ", colors.branch })
+	end
+
+	-- Add closing separator
+	if part_sep_close ~= "" and #coloreds > 0 then
+		table.insert(coloreds, { part_sep_close, "reset" })
+	end
+
+	return coloreds
+end
+
+--- Setup function to configure the git status component
+--- @param user_config? table User configuration to override defaults
+function M.setup(user_config)
+	if user_config then
+		-- Merge user config with defaults
+		for key, value in pairs(user_config) do
+			if type(value) == "table" and M.config[key] then
+				for k, v in pairs(value) do
+					M.config[key][k] = v
+				end
+			else
+				M.config[key] = value
+			end
+		end
+	end
+end
+
+--- Get git repository status as a coloreds array
+--- @param custom_config? table Optional configuration override for this call
+--- @return table coloreds Array of {text, color} pairs, empty if not in a git repo
+function M.get_status(custom_config)
+	local config = custom_config or M.config
+
+	-- Get current directory from Yazi
+	local cwd = cx.active.current.cwd
+	if not cwd then
+		return {}
+	end
+
+	local path = tostring(cwd)
+
+	-- Check cache
+	local now = os.time() * 1000 -- Convert to milliseconds
+	if cache.path == path and cache.data and (now - cache.timestamp) < config.cache_ttl then
+		return cache.data
+	end
+
+	local info = get_git_info(path)
+
+	if not info then
+		-- Clear cache if not in git repo
+		cache.path = nil
+		cache.data = nil
+		return {}
+	end
+
+	local result = format_git_info(info, config)
+
+	-- Update cache
+	cache.path = path
+	cache.data = result
+	cache.timestamp = now
+
+	return result
+end
+
+--- Create a git status component for use in yatline configuration
+--- This is the entry point for using this component in yatline
+--- @param custom_config? table Optional configuration override
+--- @return table component_config Configuration table for yatline
+function M.component(custom_config)
+	return {
+		type = "coloreds",
+		custom = true,
+		name = function()
+			return M.get_status(custom_config)
+		end
+	}
+end
+
+-- Auto-register with Yatline if available
+if Yatline and Yatline.coloreds and Yatline.coloreds.get then
+	Yatline.coloreds.get.git_repo_status = function()
+		return M.get_status()
+	end
+end
+
+return M


### PR DESCRIPTION
This plugin adds a git status of current repo to Yatline as seen on screenshot below to the left of the clock.

<img width="1877" height="132" alt="image" src="https://github.com/user-attachments/assets/026c6f5f-acea-4dee-9ee2-96de83342d37" />

More information on the plugin readme.