### PR TITLE
[BREAKING UPDATE] Reconstructing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # yatline.yazi
+
 The first Yazi plugin for customizing both header-line and status-line.
 
 ![yatline](https://github.com/user-attachments/assets/61013ec8-7fd9-42df-a9f4-f254663871fe)
@@ -7,13 +8,16 @@ The first Yazi plugin for customizing both header-line and status-line.
 > Check out [wiki](https://github.com/imsi32/yatline.yazi/wiki) for installation steps, configuration and further information.
 
 ## Features
+
 - Lualine-like Design
 - Flexible
 - Simple
 - Automatic Configuration
+- Support for Yazi Plugins
 - Themes (See: [yatline-themes](https://github.com/imsi32/yatline-themes))
 - Add-ons (See: [yatline-addons](https://github.com/imsi32/yatline-addons))
 
 ## Credits
+
 - [Lualine](https://github.com/nvim-lualine/lualine.nvim)
 - [Yazi](https://github.com/sxyazi/yazi)

--- a/main.lua
+++ b/main.lua
@@ -1050,15 +1050,15 @@ end
 --- @param line Config Configuration of either header-line or status-line.
 --- @return boolean show_line Returns yes if it contains components, otherwise returns no.
 local function show_line(line)
-	local total_components = 0
-
 	for _, side in pairs(line) do
 		for _, section in pairs(side) do
-			total_components = total_components + #section
+			if #section ~= 0 then
+				return true
+			end
 		end
 	end
 
-	return total_components ~= 0
+	return false
 end
 
 --- Creates and configures paragraph which is used as left or right of either

--- a/main.lua
+++ b/main.lua
@@ -1,4 +1,4 @@
---- @since 25.5.31
+--- @since 25.12.29
 --- @diagnostic disable: undefined-global, undefined-field
 --- @alias Mode Mode Comes from Yazi.
 --- @alias Rect Rect Comes from Yazi.

--- a/main.lua
+++ b/main.lua
@@ -1314,30 +1314,6 @@ return {
 
 		config = nil
 
-		Progress.partial_render = function(self)
-			local progress = cx.tasks.progress
-			if progress.total == 0 then
-				return config_paragraph(self._area)
-			end
-
-			local gauge = ui.Gauge():area(self._area)
-			if progress.fail == 0 then
-				gauge = gauge:gauge_style(th.status.progress_normal)
-			else
-				gauge = gauge:gauge_style(th.status.progress_error)
-			end
-
-			local percent = 99
-			if progress.found ~= 0 then
-				percent = math.min(99, ya.round(progress.processed * 100 / progress.found))
-			end
-
-			local left = progress.total - progress.succ
-			return gauge
-				:percent(percent)
-				:label(ui.Span(string.format("%3d%%, %d left", percent, left)):style(th.status.progress_label))
-		end
-
 		if display_header_line then
 			if show_line(header_line) then
 				Header.redraw = function(self)

--- a/main.lua
+++ b/main.lua
@@ -331,34 +331,27 @@ function Yatline.string.create(string, component_type)
 	return ui.Line({ span })
 end
 
---- Configuration for getting hovered file's name
---- @class HoveredNameConfig
---- @field trimed? boolean Whether to trim the filename if it's too long (default: false)
---- @field max_length? integer Maximum length of the filename (default: 24)
---- @field trim_length? integer Length of each end when trimming (default: 10)
---- @field show_symlink? boolean Whether to show symlink target (default: false)
 --- Gets the hovered file's name of the current active tab.
---- @param config? HoveredNameConfig Configuration for getting hovered file's name
+--- @param trimmed? boolean Whether to trim the filename if it's too long (default: false)
+--- @param max_length? integer Maximum length of the filename (default: 24)
+--- @param trim_length? integer Length of each end when trimming (default: 10)
+--- @param show_symlink? boolean Whether to show symlink target (default: false)
 --- @return string name Current active tab's hovered file's name
-function Yatline.string.get:hovered_name(config)
+function Yatline.string.get:hovered_name(trimmed, max_length, trim_length, show_symlink)
+	trimmed = trimmed or false
+	max_length = max_length or 24
+	trim_length = trim_length or 10
+	show_symlink = show_symlink or false
+
 	local hovered = cx.active.current.hovered
 	if not hovered then
 		return ""
 	end
 
-	if not config then
-		return hovered.name
-	end
-
-	local trimed = config.trimed or false
-	local max_length = config.max_length or 24
-	local trim_length = config.trim_length or 10
-	local show_symlink = config.show_symlink or false
-
 	local link_delimiter = " -> "
 	local linked = (show_symlink and hovered.link_to ~= nil) and (link_delimiter .. tostring(hovered.link_to)) or ""
 
-	if trimed then
+	if trimmed then
 		local trimmed_name = trim_filename(hovered.name, max_length, trim_length)
 		local trimmed_linked = #linked ~= 0
 				and link_delimiter .. trim_filename(
@@ -373,29 +366,22 @@ function Yatline.string.get:hovered_name(config)
 	end
 end
 
---- Configuration for getting hovered file's path
---- @class HoveredPathConfig
---- @field trimed? boolean Whether to trim the file path if it's too long (default: false)
---- @field max_length? integer Maximum length of the file path (default: 24)
---- @field trim_length? integer Length of each end when trimming (default: 10)
 --- Gets the hovered file's path of the current active tab.
---- @param config? HoveredPathConfig Configuration for getting hovered file's path
+--- @param trimmed? boolean Whether to trim the file path if it's too long (default: false)
+--- @param max_length? integer Maximum length of the file path (default: 24)
+--- @param trim_length? integer Length of each end when trimming (default: 10)
 --- @return string path Current active tab's hovered file's path.
-function Yatline.string.get:hovered_path(config)
+function Yatline.string.get:hovered_path(trimmed, max_length, trim_length)
+	trimmed = trimmed or false
+	max_length = max_length or 24
+	trim_length = trim_length or 10
+
 	local hovered = cx.active.current.hovered
 	if not hovered then
 		return ""
 	end
 
-	if not config then
-		return ya.readable_path(tostring(hovered.url))
-	end
-
-	local trimed = config.trimed or false
-	local max_length = config.max_length or 24
-	local trim_length = config.trim_length or 10
-
-	if trimed then
+	if trimmed then
 		return trim_filename(ya.readable_path(tostring(hovered.url)), max_length, trim_length)
 	else
 		return ya.readable_path(tostring(hovered.url))
@@ -471,18 +457,18 @@ function Yatline.string.get:hovered_file_extension(show_icon)
 	end
 end
 
---- Configuration for getting curent active tab's path
---- @class TabPathConfig
---- @field trimed? boolean Whether to trim the current active tab's path if it's too long (default: false)
---- @field max_length? integer Maximum length of the current active tab's path (default: 24)
---- @field trim_length? integer Length of each end when trimming (default: 10)
 --- Gets the path of the current active tab.
---- @param config? TabPathConfig Configuration for getting current active tab's path
+--- @param trimmed? boolean Whether to trim the current active tab's path if it's too long (default: false)
+--- @param max_length? integer Maximum length of the current active tab's path (default: 24)
+--- @param trim_length? integer Length of each end when trimming (default: 10)
 --- @return string path Current active tab's path.
-function Yatline.string.get:tab_path(config)
+function Yatline.string.get:tab_path(trimmed, max_length, trim_length)
+	trimmed = trimmed or false
+	max_length = max_length or 24
+	trim_length = trim_length or 10
+
 	local cwd = cx.active.current.cwd
 	local filter = cx.active.current.files.filter
-
 	local search = cwd.is_search and string.format(" (search: %s", cwd.frag) or ""
 
 	local suffix
@@ -494,15 +480,7 @@ function Yatline.string.get:tab_path(config)
 		suffix = string.format("%s, filter: %s)", search, tostring(filter))
 	end
 
-	if not config then
-		return ya.readable_path(tostring(cwd)) .. suffix
-	end
-
-	local trimed = config.trimed or false
-	local max_length = config.max_length or 24
-	local trim_length = config.trim_length or 10
-
-	if trimed then
+	if trimmed then
 		return trim_filename(ya.readable_path(tostring(cwd)), max_length, trim_length) .. suffix
 	else
 		return ya.readable_path(tostring(cwd)) .. suffix

--- a/main.lua
+++ b/main.lua
@@ -643,6 +643,36 @@ function Yatline.string.get:tab_path(trimmed, max_length, trim_length)
 	end
 end
 
+--- Gets the filtered query.
+--- @param key? string Key value that indicates filtered query (default: "filter:")
+--- @return string query Filtered query.
+function Yatline.string.get:filter_query(key)
+	key = key or "filter:"
+
+	local filter = cx.active.current.files.filter
+
+	if filter then
+		return string.format("%s %s", key, tostring(filter))
+	else
+		return ""
+	end
+end
+
+--- Gets the searched query.
+--- @param key? string Key value that indicates searched query (default: "search:")
+--- @return string query Searched query.
+function Yatline.string.get:search_query(key)
+	key = key or "search:"
+
+	local cwd = cx.active.current.cwd
+
+	if cwd.is_search then
+		return string.format("%s %s", key, cwd.domain)
+	else
+		return ""
+	end
+end
+
 --- Gets the mode of active tab.
 --- @return string mode Active tab's mode.
 function Yatline.string.get:tab_mode()

--- a/main.lua
+++ b/main.lua
@@ -78,10 +78,8 @@ Yatline = {}
 --- @field files {icon: string, fg: Color} Configuration for the count of files in the active tab.
 --- @field filtereds {icon: string, fg: Color} Configuration for the count of files in the active tab that are filtered.
 --- @field total {icon: string, fg: Color} Configuration for the count of progress tasks that finished.
---- @field succ {icon: string, fg: Color} Configuration for the count of progress tasks that successed.
---- @field fail {icon: string, fg: Color} Configuration for the count of progress tasks that failed.
---- @field found {icon: string, fg: Color} Configuration for the workloads of all progress tasks.
---- @field processed {icon: string, fg: Color} Configuration for the workloads of progressed tasks.
+--- @field success {icon: string, fg: Color} Configuration for the count of progress tasks that successed.
+--- @field failed {icon: string, fg: Color} Configuration for the count of progress tasks that failed.
 --- @field show_background boolean Toggle the visibility of the background where no component exists.
 --- @field display_header_line boolean Toggle the visibility of the header-line.
 --- @field display_status_line boolean Toggle the visibility of the status-line.
@@ -123,10 +121,8 @@ Yatline.config = {
 	filtereds = { icon = "", fg = "magenta" },
 
 	total = { icon = "󰮍", fg = "yellow" },
-	succ = { icon = "", fg = "green" },
-	fail = { icon = "", fg = "red" },
-	found = { icon = "󰮕", fg = "blue" },
-	processed = { icon = "󰐍", fg = "green" },
+	success = { icon = "", fg = "green" },
+	failed = { icon = "", fg = "red" },
 
 	show_background = true,
 
@@ -960,25 +956,12 @@ end
 --- Gets the number of task states.
 --- @return Coloreds coloreds Number of task states.
 function Yatline.coloreds.get:task_states()
-	local tasks = cx.tasks.progress
+	local summary = cx.tasks.summary
 
 	local coloreds = {
-		{ string.format("%s %d ", Yatline.config.total.icon, tasks.total), Yatline.config.total.fg },
-		{ string.format("%s %d ", Yatline.config.succ.icon, tasks.succ), Yatline.config.succ.fg },
-		{ string.format("%s %d", Yatline.config.fail.icon, tasks.fail), Yatline.config.fail.fg },
-	}
-
-	return coloreds
-end
-
---- Gets the number of task workloads.
---- @return Coloreds coloreds Number of task workloads.
-function Yatline.coloreds.get:task_workload()
-	local tasks = cx.tasks.progress
-
-	local coloreds = {
-		{ string.format("%s %d ", Yatline.config.found.icon, tasks.found), Yatline.config.found.fg },
-		{ string.format("%s %d", Yatline.config.processed.icon, tasks.processed), Yatline.config.processed.fg },
+		{ string.format("%s %d ", Yatline.config.total.icon, summary.total), Yatline.config.total.fg },
+		{ string.format("%s %d ", Yatline.config.success.icon, summary.success), Yatline.config.success.fg },
+		{ string.format("%s %d", Yatline.config.failed.icon, summary.failed), Yatline.config.failed.fg },
 	}
 
 	return coloreds

--- a/main.lua
+++ b/main.lua
@@ -199,17 +199,62 @@ local function set_mode_style(mode)
 	end
 end
 
+--- Helper function to apply style table to a component
+--- @param component Span The component to style
+--- @param style table The style table with fg and/or bg fields
+local function apply_style_table(component, style)
+	if not style then
+		return component
+	end
+	-- Apply manually
+	if style.fg then
+		component:fg(style.fg)
+	end
+	if style.bg then
+		component:bg(style.bg)
+	end
+	if style.bold then
+		component:bold()
+	end
+	if style.dim then
+		component:dim()
+	end
+	if style.italic then
+		component:italic()
+	end
+	if style.underline then
+		component:underline()
+	end
+	if style.blink then
+		component:blink()
+	end
+	if style.blink_rapid then
+		component:blink_rapid()
+	end
+	if style.reverse then
+		component:reverse()
+	end
+	if style.hidden then
+		component:hidden()
+	end
+	if style.crossed then
+		component:crossed()
+	end
+
+	return component
+end
+
 --- Sets the style of the component according to the its type.
 --- @param component Span Component that will be styled.
 --- @param component_type ComponentType Which section component will be in [ a | b | c ].
 --- @see Style To see how to style, in Yazi's documentation.
 local function set_component_style(component, component_type)
 	if component_type == ComponentType.A then
-		component:style(Yatline.config.style_a):bold()
+		apply_style_table(component, style_a):bold()
 	elseif component_type == ComponentType.B then
-		component:style(Yatline.config.style_b)
+		apply_style_table(component, style_b)
 	else
-		component:style(Yatline.config.style_c)
+		apply_style_table(component, style_c)
 	end
 end
 
@@ -262,8 +307,8 @@ local function connect_separator(component, in_side, separator_type, separator_s
 		close = ui.Span(Yatline.config.part_separator.close)
 	end
 
-	open:style(separator_style)
-	close:style(separator_style)
+	apply_style_table(open, separator_style)
+	apply_style_table(close, separator_style)
 
 	if in_side == Side.LEFT then
 		return ui.Line({ component, close })
@@ -729,7 +774,7 @@ function Yatline.line.get:tabs(side)
 				set_component_style(outer, ComponentType.C)
 				set_component_style(tab, ComponentType.C)
 			else
-				tab:style({ fg = Yatline.config.style_c.fg })
+				apply_style_table(tab, { fg = Yatline.config.style_c.fg })
 			end
 
 			if in_side == Side.LEFT then
@@ -773,8 +818,8 @@ function Yatline.line.get:tabs(side)
 					close = ui.Span(Yatline.config.part_separator.close)
 				end
 
-				open:style(separator_style)
-				close:style(separator_style)
+				apply_style_table(open, separator_style)
+				apply_style_table(close, separator_style)
 
 				if in_side == Side.LEFT then
 					lines[#lines + 1] = ui.Line({ tab, close })
@@ -1153,7 +1198,7 @@ end
 local function config_paragraph(area, line)
 	local line_array = { line } or {}
 	if Yatline.config.show_background then
-		return ui.Text(line_array):area(area):style(Yatline.config.style_c)
+		return apply_style_table(ui.Text(line_array):area(area), Yatline.config.style_c)
 	else
 		return ui.Text(line_array):area(area)
 	end

--- a/main.lua
+++ b/main.lua
@@ -698,7 +698,7 @@ function Yatline.line.get:tabs(side)
 	for i = 1, tabs do
 		local text = tostring(i)
 		if Yatline.config.tab_width > 2 then
-			text = ya.truncate(text .. " " .. cx.tabs[i].name, { max = Yatline.config.tab_width })
+			text = ui.truncate(text .. " " .. cx.tabs[i].name, { max = Yatline.config.tab_width })
 		end
 
 		local separator_style = { bg = nil, fg = nil }

--- a/main.lua
+++ b/main.lua
@@ -179,14 +179,6 @@ Yatline.config = {
 	},
 }
 
---=========================--
--- Variable Initialization --
---=========================--
-
---- Holds the style of the separator.
---- @type {bg: string?, fg: string?}
-local separator_style = { bg = nil, fg = nil }
-
 --=================--
 -- Component Setup --
 --=================--
@@ -222,8 +214,9 @@ end
 --- @param component Span Component that will be connected to separator.
 --- @param in_side Side Left or right side of the either header-line or status-line.
 --- @param separator_type SeparatorType Where will there be a separator in the section.
+--- @param separator_style {bg: string?, fg: string?} Holds the style of the separator.
 --- @return Line line A Line which may have either both component and separator, or component.
-local function connect_separator(component, in_side, separator_type)
+local function connect_separator(component, in_side, separator_type, separator_style)
 	local open, close
 	if
 		separator_type == SeparatorType.OUTER and not (separator_style.bg == "reset" and separator_style.fg == "reset")
@@ -682,7 +675,7 @@ function Yatline.line.get:tabs(side)
 			text = ya.truncate(text .. " " .. cx.tabs[i].name, { max = Yatline.config.tab_width })
 		end
 
-		separator_style = { bg = nil, fg = nil }
+		local separator_style = { bg = nil, fg = nil }
 		if i == cx.tabs.idx then
 			local span = ui.Span(" " .. text .. " ")
 			set_mode_style(cx.tabs[i].mode)
@@ -694,11 +687,11 @@ function Yatline.line.get:tabs(side)
 					separator_style.bg = Yatline.config.style_c.bg
 				end
 
-				lines[#lines + 1] = connect_separator(span, in_side, SeparatorType.OUTER)
+				lines[#lines + 1] = connect_separator(span, in_side, SeparatorType.OUTER, separator_style)
 			else
 				separator_style.fg = Yatline.config.style_a.fg
 
-				lines[#lines + 1] = connect_separator(span, in_side, SeparatorType.INNER)
+				lines[#lines + 1] = connect_separator(span, in_side, SeparatorType.INNER, separator_style)
 			end
 		else
 			local span = ui.Span(" " .. text .. " ")
@@ -757,7 +750,7 @@ function Yatline.line.get:tabs(side)
 					separator_style.bg = Yatline.config.style_c.bg
 				end
 
-				lines[#lines + 1] = connect_separator(span, in_side, SeparatorType.INNER)
+				lines[#lines + 1] = connect_separator(span, in_side, SeparatorType.INNER, separator_style)
 			end
 		end
 	end
@@ -967,7 +960,7 @@ local function config_components_separators(
 	local section_line_components = {}
 	for i, component in ipairs(section_components) do
 		if component[2] == true then -- Does component have separator?
-			separator_style = { bg = nil, fg = nil }
+			local separator_style = { bg = nil, fg = nil }
 
 			local separator_type
 			if i ~= num_section_components then -- Does component is not at the end of the section?
@@ -1002,7 +995,7 @@ local function config_components_separators(
 				end
 			end
 
-			section_line_components[i] = connect_separator(component[1], in_side, separator_type)
+			section_line_components[i] = connect_separator(component[1], in_side, separator_type, separator_style)
 		else
 			section_line_components[i] = component[1]
 		end

--- a/main.lua
+++ b/main.lua
@@ -910,61 +910,111 @@ end
 
 --- Gets the number of selected and yanked files and also number of files or filtered files of the active tab.
 --- @param filter? boolean Whether or not number of files (or filtered files) will be shown.
---- @return Coloreds coloreds Active tab's number of selected and yanked files and also number of files or filtered files
-function Yatline.coloreds.get:count(filter)
+--- @param zero_check? boolean Whether or not counts will be shown if count is zero.
+--- @return Coloreds? coloreds Active tab's number of selected and yanked files and also number of files or filtered files
+function Yatline.coloreds.get:count(filter, zero_check)
 	filter = filter or false
+	zero_check = zero_check or false
 
 	local num_yanked = #cx.yanked
 	local num_selected = #cx.active.selected
 	local num_files = #cx.active.current.files
 
-	local yanked_fg, yanked_icon
-	if cx.yanked.is_cut then
-		yanked_fg = Yatline.config.cut.fg
-		yanked_icon = Yatline.config.cut.icon
-	else
-		yanked_fg = Yatline.config.copied.fg
-		yanked_icon = Yatline.config.copied.icon
-	end
+	local coloreds = {}
 
-	local files_count_fg, files_count_icon
-	if cx.active.current.files.filter or cx.active.current.cwd.is_search then
-		files_count_fg = Yatline.config.filtereds.fg
-		files_count_icon = Yatline.config.filtereds.icon
-	else
-		files_count_fg = Yatline.config.files.fg
-		files_count_icon = Yatline.config.files.icon
-	end
-
-	local coloreds
 	if filter then
-		coloreds = {
-			{ string.format("%s %d ", files_count_icon, num_files), files_count_fg },
-			{ string.format("%s %d ", Yatline.config.selected.icon, num_selected), Yatline.config.selected.fg },
-			{ string.format("%s %d", yanked_icon, num_yanked), yanked_fg },
-		}
-	else
-		coloreds = {
-			{ string.format("%s %d ", Yatline.config.selected.icon, num_selected), Yatline.config.selected.fg },
-			{ string.format("%s %d", yanked_icon, num_yanked), yanked_fg },
-		}
+		local files_count_fg, files_count_icon
+		if cx.active.current.files.filter or cx.active.current.cwd.is_search then
+			files_count_fg = Yatline.config.filtereds.fg
+			files_count_icon = Yatline.config.filtereds.icon
+		else
+			files_count_fg = Yatline.config.files.fg
+			files_count_icon = Yatline.config.files.icon
+		end
+
+		if (zero_check and num_files > 0) or not zero_check then
+			table.insert(coloreds, { string.format("%s %d", files_count_icon, num_files), files_count_fg })
+		end
 	end
 
-	return coloreds
+	if (zero_check and num_selected > 0) or not zero_check then
+		if #coloreds > 0 then
+			table.insert(coloreds, { " ", Yatline.config.selected.fg })
+		end
+
+		table.insert(
+			coloreds,
+			{ string.format("%s %d", Yatline.config.selected.icon, num_selected), Yatline.config.selected.fg }
+		)
+	end
+
+	if (zero_check and num_yanked > 0) or not zero_check then
+		local yanked_fg, yanked_icon
+		if cx.yanked.is_cut then
+			yanked_fg = Yatline.config.cut.fg
+			yanked_icon = Yatline.config.cut.icon
+		else
+			yanked_fg = Yatline.config.copied.fg
+			yanked_icon = Yatline.config.copied.icon
+		end
+
+		if #coloreds > 0 then
+			table.insert(coloreds, { " ", yanked_fg })
+		end
+
+		table.insert(coloreds, { string.format("%s %d", yanked_icon, num_yanked), yanked_fg })
+	end
+
+	if #coloreds > 0 then
+		return coloreds
+	else
+		return nil
+	end
 end
 
 --- Gets the number of task states.
---- @return Coloreds coloreds Number of task states.
-function Yatline.coloreds.get:task_states()
+--- @param zero_check? boolean Whether or not counts will be shown if count is zero.
+--- @return Coloreds? coloreds Number of task states.
+function Yatline.coloreds.get:task_states(zero_check)
+	zero_check = zero_check or false
+
 	local summary = cx.tasks.summary
+	local coloreds = {}
 
-	local coloreds = {
-		{ string.format("%s %d ", Yatline.config.total.icon, summary.total), Yatline.config.total.fg },
-		{ string.format("%s %d ", Yatline.config.success.icon, summary.success), Yatline.config.success.fg },
-		{ string.format("%s %d", Yatline.config.failed.icon, summary.failed), Yatline.config.failed.fg },
-	}
+	if (zero_check and summary.total > 0) or not zero_check then
+		table.insert(
+			coloreds,
+			{ string.format("%s %d", Yatline.config.total.icon, summary.total), Yatline.config.total.fg }
+		)
+	end
 
-	return coloreds
+	if (zero_check and summary.success > 0) or not zero_check then
+		if #coloreds > 0 then
+			table.insert(coloreds, { " ", Yatline.config.success.fg })
+		end
+
+		table.insert(
+			coloreds,
+			{ string.format("%s %d", Yatline.config.success.icon, summary.success), Yatline.config.success.fg }
+		)
+	end
+
+	if (zero_check and summary.failed > 0) or not zero_check then
+		if #coloreds > 0 then
+			table.insert(coloreds, { " ", Yatline.config.failed.fg })
+		end
+
+		table.insert(
+			coloreds,
+			{ string.format("%s %d", Yatline.config.failed.icon, summary.failed), Yatline.config.failed.fg }
+		)
+	end
+
+	if #coloreds > 0 then
+		return coloreds
+	else
+		return nil
+	end
 end
 
 --- Gets colored which contains string based component's string and desired foreground color.

--- a/main.lua
+++ b/main.lua
@@ -250,11 +250,11 @@ end
 --- @see Style To see how to style, in Yazi's documentation.
 local function set_component_style(component, component_type)
 	if component_type == ComponentType.A then
-		apply_style_table(component, style_a):bold()
+		apply_style_table(component, Yatline.config.style_a):bold()
 	elseif component_type == ComponentType.B then
-		apply_style_table(component, style_b)
+		apply_style_table(component, Yatline.config.style_b)
 	else
-		apply_style_table(component, style_c)
+		apply_style_table(component, Yatline.config.style_c)
 	end
 end
 

--- a/main.lua
+++ b/main.lua
@@ -625,7 +625,7 @@ function Yatline.string.get:tab_path(trimmed, max_length, trim_length)
 
 	local cwd = cx.active.current.cwd
 	local filter = cx.active.current.files.filter
-	local search = cwd.is_search and string.format(" (search: %s", cwd.frag) or ""
+	local search = cwd.is_search and string.format(" (search: %s", cwd.domain) or ""
 
 	local suffix
 	if not filter then

--- a/main.lua
+++ b/main.lua
@@ -625,15 +625,24 @@ function Yatline.string.get:tab_path(trimmed, max_length, trim_length)
 
 	local cwd = cx.active.current.cwd
 	local filter = cx.active.current.files.filter
-	local search = cwd.is_search and string.format(" (search: %s", cwd.domain) or ""
+	local finder = cx.active.finder
+
+	local t = {}
+	if cwd.is_search then
+		t[#t + 1] = string.format("search: %s", cwd.domain)
+	end
+	if filter then
+		t[#t + 1] = string.format("filter: %s", filter)
+	end
+	if finder then
+		t[#t + 1] = string.format("find: %s", finder)
+	end
 
 	local suffix
-	if not filter then
-		suffix = search == "" and search or search .. ")"
-	elseif search == "" then
-		suffix = string.format(" (filter: %s)", tostring(filter))
+	if #t ~= 0 then
+		suffix = " (" .. table.concat(t, ", ") .. ")"
 	else
-		suffix = string.format("%s, filter: %s)", search, tostring(filter))
+		suffix = ""
 	end
 
 	if trimmed then
@@ -668,6 +677,21 @@ function Yatline.string.get:search_query(key)
 
 	if cwd.is_search then
 		return string.format("%s %s", key, cwd.domain)
+	else
+		return ""
+	end
+end
+
+--- Gets the finded query.
+--- @param key? string Key value that indicates finded query (default: "find:")
+--- @return string query Finded query.
+function Yatline.string.get:finder_query(key)
+	key = key or "find:"
+
+	local finder = cx.active.finder
+
+	if finder then
+		return string.format("%s %s", key, tostring(finder))
 	else
 		return ""
 	end

--- a/main.lua
+++ b/main.lua
@@ -1184,21 +1184,24 @@ return {
 
 		if Yatline.config.display_header_line then -- Controls displaying header-line.
 			if show_line(Yatline.config.header_line) then -- Controls recoding of header-line.
+				-- Empties default Yazi header-line.
+				Header._left = {}
+				Header._right = {}
+
 				Header.redraw = function(self)
+					-- Gets Yazi components.
+					local right = self:children_redraw(self.RIGHT)
+					self._right_width = right:width()
+					local left = self:children_redraw(self.LEFT)
+
+					-- Gets Yatline components.
 					local left_line = config_line(Yatline.config.header_line.left, Side.LEFT)
 					local right_line = config_line(Yatline.config.header_line.right, Side.RIGHT)
 
 					return {
-						config_paragraph(self._area, left_line), -- Styles left_line if show_background set.
-						right_line:area(self._area):align(ui.Align.RIGHT),
+						config_paragraph(self._area, ui.Line({ left_line, left })), -- Styles left_line if show_background set.
+						ui.Line({ right, right_line }):area(self._area):align(ui.Align.RIGHT),
 					}
-				end
-
-				Header.children_add = function()
-					return {}
-				end
-				Header.children_remove = function()
-					return {}
 				end
 			end
 		else
@@ -1209,22 +1212,25 @@ return {
 
 		if Yatline.config.display_status_line then -- Controls displaying status-line.
 			if show_line(Yatline.config.status_line) then -- Controls recoding of status-line.
+				-- Empties default Yazi status-line.
+				Status._left = {}
+				Status._right = {}
+
 				Status.redraw = function(self)
+					-- Gets Yazi components.
+					local left = self:children_redraw(self.LEFT)
+					local right = self:children_redraw(self.RIGHT)
+
+					-- Gets Yatline components.
 					local left_line = config_line(Yatline.config.status_line.left, Side.LEFT)
 					local right_line = config_line(Yatline.config.status_line.right, Side.RIGHT)
 
+					local sum_right = ui.Line({ right, right_line }) -- Needed for error prevention.
 					return {
-						config_paragraph(self._area, left_line), -- Styles left_line if show_background set.
-						right_line:area(self._area):align(ui.Align.RIGHT),
-						table.unpack(ui.redraw(Progress:new(self._area, right_line:width()))), -- Inserts Progress bar.
+						config_paragraph(self._area, ui.Line({ left_line, left })), -- Styles left_line if show_background set.
+						sum_right:area(self._area):align(ui.Align.RIGHT),
+						table.unpack(ui.redraw(Progress:new(self._area, sum_right:width()))), -- Inserts Progress bar.
 					}
-				end
-
-				Status.children_add = function()
-					return {}
-				end
-				Status.children_remove = function()
-					return {}
 				end
 			end
 		else


### PR DESCRIPTION
**Features:**

- Yazi v25.12.29 support.
- Some improvements to the configuration initialization.
- Shared configuration across add-ons.
- Yazi plugins or components are usable without adjusting to Yatline.
- Padding around components can be adjusted.
- Count and task states components can be hidden using new parameter if their values are zero.
- New components for search, filter and finder queries.

**Breaking Changes:**

- Components that has feature for trimming names took parameters in a single table unlike other components. They are now take them in multiple parameters.
-  Task workload component removed because its values no longer changes.
- The way to use default Yatline configuration changed.

Resolves: #50 #60 #61 #62 #64 